### PR TITLE
Fix "self" is not defined ReferenceError

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = {
     library: {
       type: 'umd'
     },
+    globalObject: 'this',
   },
   resolve: {
     extensions: ['.ts', '.tsx', '.js'],


### PR DESCRIPTION
Source: https://stackoverflow.com/questions/64639839/typescript-webpack-library-generates-referenceerror-self-is-not-defined