### PR TITLE
Dates and Guids

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,6 @@
   },
   "plugins": ["@typescript-eslint"],
   "rules": {
-    "indent": ["warn", 2],
     "quotes": ["warn", "single"],
     "semi": ["warn", "always"],
     "@typescript-eslint/no-inferrable-types": "off"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-builder-odata",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "keywords": [
     "odata",
     "odata v4",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,3 +28,8 @@ export class StringOperator {
   public static readonly endsWith = 'endswith';
   public static readonly contains = 'contains';
 }
+
+export class ParameterType {
+  public static readonly datetime = 'datetime';
+  public static readonly guid = 'guid';
+}

--- a/src/filter-builder.ts
+++ b/src/filter-builder.ts
@@ -1,4 +1,4 @@
-import { LogicalOperator, ComparisonOperator, StringOperator } from './constants';
+import { LogicalOperator, ComparisonOperator, StringOperator, ParameterType } from './constants';
 import { replaceSpecialCharacters } from './helper';
 
 export class FilterBuilder {
@@ -10,32 +10,32 @@ export class FilterBuilder {
   }
 
   public and(...callbacks: ((buider: FilterBuilder) => void)[]): FilterBuilder {
-    return this.logical(LogicalOperator.and, ...callbacks);
+    return this.logical(LogicalOperator.and, callbacks);
   }
   public or(...callbacks: ((buider: FilterBuilder) => void)[]): FilterBuilder {
-    return this.logical(LogicalOperator.or, ...callbacks);
+    return this.logical(LogicalOperator.or, callbacks);
   }
 
-  public eq(property: string, value: string | number): FilterBuilder {
-    return this.comparison(property, ComparisonOperator.eq, value);
+  public eq(property: string, value: string | number, type?: ParameterType): FilterBuilder {
+    return this.comparison(property, ComparisonOperator.eq, [value], type);
   }
-  public ne(property: string, value: string | number): FilterBuilder {
-    return this.comparison(property, ComparisonOperator.ne, value);
+  public ne(property: string, value: string | number, type?: ParameterType): FilterBuilder {
+    return this.comparison(property, ComparisonOperator.ne, [value], type);
   }
-  public gt(property: string, value: string | number): FilterBuilder {
-    return this.comparison(property, ComparisonOperator.gt, value);
+  public gt(property: string, value: string | number, type?: ParameterType): FilterBuilder {
+    return this.comparison(property, ComparisonOperator.gt, [value], type);
   }
-  public ge(property: string, value: string | number): FilterBuilder {
-    return this.comparison(property, ComparisonOperator.ge, value);
+  public ge(property: string, value: string | number, type?: ParameterType): FilterBuilder {
+    return this.comparison(property, ComparisonOperator.ge, [value], type);
   }
-  public lt(property: string, value: string | number): FilterBuilder {
-    return this.comparison(property, ComparisonOperator.lt, value);
+  public lt(property: string, value: string | number, type?: ParameterType): FilterBuilder {
+    return this.comparison(property, ComparisonOperator.lt, [value], type);
   }
-  public le(property: string, value: string | number): FilterBuilder {
-    return this.comparison(property, ComparisonOperator.le, value);
+  public le(property: string, value: string | number, type?: ParameterType): FilterBuilder {
+    return this.comparison(property, ComparisonOperator.le, [value], type);
   }
-  public in(property: string, values: (string | number)[]): FilterBuilder {
-    return this.comparison(property, ComparisonOperator.in, ...values);
+  public in(property: string, values: (string | number)[], type?: ParameterType): FilterBuilder {
+    return this.comparison(property, ComparisonOperator.in, values, type);
   }
 
   public startsWith(property: string, value: string | number): FilterBuilder {
@@ -52,24 +52,27 @@ export class FilterBuilder {
     const f = this.filter.join(` ${this.operator} `);
     return f.match(/^\(.*\)$/) ? f.substr(1, f.length - 2) : f;
   }
-  private logical(op: LogicalOperator, ...callbacks: ((buider: FilterBuilder) => void)[]): FilterBuilder {
+  private logical(op: LogicalOperator, callbacks: ((buider: FilterBuilder) => void)[]): FilterBuilder {
     const b = new FilterBuilder(op);
     callbacks.forEach(c => c(b));
     this.filter.push(`(${b.toQuery()})`);
     return this;
   }
-  private comparison(property: string, op: ComparisonOperator, ...values: (string | number)[]): FilterBuilder {
-    const value = this.stringify(...values);
+  private comparison(property: string, op: ComparisonOperator, values: (string | number | Date)[], type?: ParameterType): FilterBuilder {
+    const value = this.stringify(values, type);
     this.filter.push(`${property} ${op} ${value}`);
     return this;
   }
   private stringFunction(op: StringOperator, property: string, value: string | number): FilterBuilder {
-    value = this.stringify(value);
+    value = this.stringify([value]);
     this.filter.push(`${op}(${property}, ${value})`);
     return this;
   }
-  private stringify(...values: (string | number)[]): string {
-    values = values.map(v => typeof v === 'string' ? `'${replaceSpecialCharacters(v)}'` : v);
+  private stringify(values: (string | number | Date)[], type?: ParameterType): string {
+    if (type === undefined) {
+      values = values.map(v => typeof v === 'string' ? `'${replaceSpecialCharacters(v)}'` : v);
+    }
+    // do nothing with the current parameter types
     const value = values.join(',');
     return values.length > 1 ? `(${value})` : value;
   }

--- a/test/filter-builder.test.ts
+++ b/test/filter-builder.test.ts
@@ -1,3 +1,4 @@
+import { ParameterType } from '../src/constants';
 import { QueryBuilder } from '../src/query-builder';
 
 describe('and', () => {
@@ -100,4 +101,21 @@ describe('contains', () => {
     const expected = '?$filter=contains(name, \'John\')';
     expect(query).toEqual(expected);
   });
+});
+
+describe('comparison operators with optional parameter types', () => {
+  it('datetime', () => {
+    const query = new QueryBuilder()
+      .filter(f => f.eq('publishdate', '2022-02-01', ParameterType.datetime))
+      .toQuery();
+    const expected = '?$filter=publishdate eq 2022-02-01';
+    expect(query).toEqual(expected);
+  });
+  it('guid', () => {
+    const query = new QueryBuilder()
+      .filter(f => f.eq('guid', '7bd6b28d-68e7-4d21-b540-3377380ce468', ParameterType.guid))
+      .toQuery();
+    const expected = '?$filter=guid eq 7bd6b28d-68e7-4d21-b540-3377380ce468';
+    expect(query).toEqual(expected);
+  }); 
 });


### PR DESCRIPTION
Adds support for Dates and Guids in comparison operators with a third optional parameter, example:
```
const query = new QueryBuilder()
      .filter(f => f.eq('publishdate', '2022-02-01', ParameterType.datetime)) // or "datetime"
      .toQuery();
query => '?$filter=publishdate eq 2022-02-01';
```
```
const query = new QueryBuilder()
      .filter(f => f.eq('guid', '7bd6b28d-68e7-4d21-b540-3377380ce468', ParameterType.guid)) // or "guid"
      .toQuery();
query => '?$filter=guid eq 7bd6b28d-68e7-4d21-b540-3377380ce468';
```

closes #6 